### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/esp-rs/riscv-atomic-emulation-trap"
 
 [dependencies]
-riscv = "0.7.0"
-riscv-rt = "0.8.1"
+riscv = "0.8.0"
+riscv-rt = "0.9.0"
 
 [build-dependencies]
 riscv-target = "0.1.2"


### PR DESCRIPTION
This updates `riscv` to _0.8.0_ and `riscv-rt` to _0.9.0_