### PR TITLE
update to 0.1.1 to allow updating the crate.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riscv-atomic-emulation-trap"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "An atomic emulation trap handler for non atomic RISCV targets."
 keywords = ["RISCV", "emulation", "atomic"]


### PR DESCRIPTION
The version 0.1.0 published in crate.io has riscv-rt with version `0.8.1` but the latest of the esp32-common-hal requires `0.9.0` causing linking problems. But the master  toml file has:
```
riscv = "0.8.0"
riscv-rt = "0.9.0"
```
which are aligned, so ideally, you should publish the `0.1.1` to solve the issue.