### PR TITLE
Pass instruction instead of pc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,9 @@ pub fn is_atomic_instruction(insn: usize) -> bool {
 /// Takes the program counter address that triggered the exception and an array of
 /// registers at point of exception with [`PLATFORM_REGISTER_LEN`] length.
 /// Returns true if the instruction was atomic and was emulated, false otherwise.
-/// 
+///
 /// # Safety
-/// 
+///
 /// This function is supposed to be called right after the instruction caused an exception.
 /// Thus, it assumes that the program counter is valid and points to a valid instruction.
 /// It also assumes that all the user registers were correctly saved and sorted in a trap frame.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,24 +13,27 @@ macro_rules! amo {
     };
 }
 
-/// is_atomic_instruction
-/// 
-/// Take the program counter address and returns whether the instruction at that address is an atomic one
-pub unsafe fn is_atomic_instruction(pc: usize) -> bool {
-    (*(pc as *const usize) & 0b1111111) == 0b0101111
+/// Checks if the instruction is an atomic one.
+#[inline(always)]
+pub fn is_atomic_instruction(insn: usize) -> bool {
+    (insn & 0b1111111) == 0b0101111
 }
 
-/// atomic_emulation
+/// Takes the instruction that triggered the exception and an array of
+/// registers at point of exception with [`PLATFORM_REGISTER_LEN`] length.
+/// Returns true if the instruction was atomic and was emulated, false otherwise.
 /// 
-/// Takes the exception program counter and an array of registers at point of exception with [`PLATFORM_REGISTER_LEN`] length.
-pub unsafe fn atomic_emulation(pc: usize, frame: &mut [usize; PLATFORM_REGISTER_LEN]) -> bool {
+/// # Safety
+/// 
+/// This function is supposed to be called right after the instruction caused an exception.
+/// It also assumes that all the user registers were correctly saved and sorted in a trap frame.
+#[inline]
+pub unsafe fn atomic_emulation(insn: usize, frame: &mut [usize; PLATFORM_REGISTER_LEN]) -> bool {
     static mut S_LR_ADDR: usize = 0;
 
-    if !is_atomic_instruction(pc) {
+    if !is_atomic_instruction(insn) {
         return false;
     }
-
-    let insn: usize = *(pc as *const _);
 
     let reg_mask = 0b11111;
     // destination register


### PR DESCRIPTION
I'm developing a new feature to the `riscv-rt` that uses this crate to emulate atomic operations if needed. The idea of this feature is to natively define the alternative trap handler without boilerplate translations etc. to speed up a bit the performance. I already have a working version, but first I need to push small contributions that I made to make it work. One of them is this one.

My RISC-V board uses compressed instructions, and sometimes the atomic instructions are not aligned. Thus, the current version of this crate throws an exception when reading the instruction. I thought that the most elegant approach for fixing this issue was changing the crate to expect the instruction itself instead of the program counter. Thus, the exception handler would now be in charge of reading the instruction as required by the platform. I also added a few lines of documentation and `#[inline]` annotations, feel free to ask me for changes.

Let me know what you think. We could use `core::ptr::read_unaligned` instead, but I thought this other approach was cleaner.